### PR TITLE
Fix path to client build folder

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -18,9 +18,10 @@ app.get('/api/kits', async (req, res) => { res.json(await Kit.find({})); });
 
 // Serve React build in production
 if (process.env.NODE_ENV === 'production') {
-  app.use(express.static(path.join(__dirname, '../cliente/build')));
+  // Serve the React app from the correct build directory
+  app.use(express.static(path.join(__dirname, '../client/build')));
   app.get('*', (req, res) => {
-    res.sendFile(path.join(__dirname, '../cliente/build', 'index.html'));
+    res.sendFile(path.join(__dirname, '../client/build', 'index.html'));
   });
 }
 


### PR DESCRIPTION
## Summary
- correct the build path in the Express server so the React app is served in production

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_686ae739da508326894ef1c6af3efe3e