### PR TITLE
Add basic vehicle kit store example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
-# Project Structure and Complete Configuration
+# AJ Garage DIY
 
-This repository AGARAGE/pagina-weeb uses Spanish folder names for frontend and backend.
+Este proyecto es una demostraci\u00f3n sencilla de una web para vender kits de mantenimiento de veh\u00edculos desde el a\u00f1o 2000 en adelante. Incluye un backend con Express y MongoDB y un frontend creado con React.
+
+## Estructura
+- **server**: servidor Express con una colecci\u00f3n `Kit`.
+- **client**: aplicaci\u00f3n React que consume la API y muestra los kits disponibles.
+
+## Puesta en marcha
+1. Instalar dependencias en `server` y `client`:
+   ```bash
+   cd server && npm install
+   cd ../client && npm install
+   ```
+2. Iniciar MongoDB en local y ejecutar el servidor:
+   ```bash
+   cd ../server
+   npm start
+   ```
+3. En otra terminal arrancar el cliente React:
+   ```bash
+   cd ../client
+   npm start
+   ```
+
+Al iniciarse el servidor, se poblar\u00e1 la base de datos con algunos kits de ejemplo.

--- a/client/package.json
+++ b/client/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "dependencies": {
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "react-scripts": "5.0.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import KitList from './KitList.jsx';
 
 export default function App() {
   return (
     <div>
       <h1>Welcome to AJ Garage DIY</h1>
+      <KitList />
     </div>
   );
 }

--- a/client/src/KitList.jsx
+++ b/client/src/KitList.jsx
@@ -1,0 +1,26 @@
+import React, { useEffect, useState } from 'react';
+
+export default function KitList() {
+  const [kits, setKits] = useState([]);
+
+  useEffect(() => {
+    fetch('/api/kits')
+      .then(res => res.json())
+      .then(setKits)
+      .catch(() => setKits([]));
+  }, []);
+
+  return (
+    <div>
+      <h2>Kits disponibles</h2>
+      <ul>
+        {kits.map(kit => (
+          <li key={kit._id}>
+            <strong>{kit.nivel}</strong> - {kit.marca} {kit.modelo} {kit.ano}
+            {' '}<a href={kit.linkCompra}>Comprar</a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App.jsx';
+
+const root = createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/server/models/Kit.js
+++ b/server/models/Kit.js
@@ -5,7 +5,11 @@ const kitSchema = new mongoose.Schema({
   modelo: String,
   ano: Number,
   elementos: [String],
-  nivel: { type: String, enum: ['Básico','Intermedio','Completo'] }
+  nivel: {
+    type: String,
+    enum: ['Básico', 'Intermedio', 'Completo', 'Frenos']
+  },
+  linkCompra: String
 });
 
 export default mongoose.model('Kit', kitSchema);

--- a/server/server.js
+++ b/server/server.js
@@ -2,6 +2,7 @@ import express from 'express';
 import mongoose from 'mongoose';
 import cors from 'cors';
 import path from 'path';
+import Kit from './models/Kit.js';
 
 const app = express();
 const PORT = process.env.PORT || 5000;
@@ -10,17 +11,40 @@ const MONGO_URI = process.env.MONGO_URI || 'mongodb://localhost:27017/ajgarage';
 app.use(cors());
 app.use(express.json());
 mongoose.connect(MONGO_URI, { useNewUrlParser: true, useUnifiedTopology: true });
+mongoose.connection.once('open', seedKits);
 
-const kitSchema = new mongoose.Schema({ marca: String, modelo: String, ano: Number, elementos: [String], nivel: String });
-const Kit = mongoose.model('Kit', kitSchema);
+// Simple seed data for first run
+async function seedKits() {
+  const count = await Kit.countDocuments();
+  if (count === 0) {
+    await Kit.create([
+      {
+        marca: 'Universal',
+        modelo: 'Sedan',
+        ano: 2000,
+        elementos: ['Aceite', 'Filtro', 'Guantes'],
+        nivel: 'Básico',
+        linkCompra: 'https://ejemplo.com/kit-basico'
+      },
+      {
+        marca: 'Universal',
+        modelo: 'SUV',
+        ano: 2005,
+        elementos: ['Pastillas de freno', 'Gato hidráulico', 'Guantes'],
+        nivel: 'Frenos',
+        linkCompra: 'https://ejemplo.com/kit-frenos'
+      }
+    ]);
+  }
+}
 
 app.get('/api/kits', async (req, res) => { res.json(await Kit.find({})); });
 
 // Serve React build in production
 if (process.env.NODE_ENV === 'production') {
-  app.use(express.static(path.join(__dirname, '../cliente/build')));
+  app.use(express.static(path.join(__dirname, '../client/build')));
   app.get('*', (req, res) => {
-    res.sendFile(path.join(__dirname, '../cliente/build', 'index.html'));
+    res.sendFile(path.join(__dirname, '../client/build', 'index.html'));
   });
 }
 


### PR DESCRIPTION
## Summary
- expand Kit model with new fields including purchase link
- seed database with example kits on server start
- serve React build from `client` directory
- add React component to list kits
- create entry point for React app
- update package.json dependencies and README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ae8d89ec88326ad86af88361e333f